### PR TITLE
Update Feature Parity Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,19 +1213,19 @@ DateTime.local().isValid;
 | ---------------------------------- | ---------- | --------- | ------------ | --------- |
 |     **Parse**                          |            |           |              |           |
 |     String   + Date Format         |     ✅      |     ✅     |     ✅        |     ✅     |
-|     String   + Time Format         |     ✅      |     ✅     |     ✅        |     ⚠️    |
-|     String   + Format + locale     |     ❌      | ⚠️        |     ✅        |     ⚠️    |
+|     String   + Time Format         |     ✅      |     ✅     |     ✅        |     ✅    |
+|     String   + Format + locale     |     ❌      | ⚠️        |     ✅        |     ✅    |
 |                                    |            |           |              |           |
 |     **Get + Set**                     |            |           |              |           |
 |     Millisecond/Second/Minute/Hour |     ✅      |     ✅     |     ✅        |     ✅     |
 |     Date   of Month                |     ✅      |     ✅     |     ✅        |     ✅     |
 |     Day   of Week                  |     ✅      |     ✅     |     ✅        |     ✅     |
 |     Day   of Year                  |     ✅      |     ✅     |     ✅        |     ✅     |
-|     Week   of Year                 |     ✅      |     ✅     |     ✅        |     ⚠️    |
-|     Days   in Month                |     ✅      |     ✅     |     ✅        |     ⚠️    |
-|     Weeks   in Year                |     ❌      |     ❌     |     ✅        |      ❌     |
-|     Maximum   of the given dates   |     ✅      |     ✅     |     ✅        | ⚠️        |
-|     Minimum   of the given dates   |     ✅      |     ✅     |     ✅        |     ⚠️    |
+|     Week   of Year                 |     ✅      |     ✅     |     ✅        |     ✅    |
+|     Days   in Month                |     ✅      |     ✅     |     ✅        |     ✅    |
+|     Weeks   in Year                |     ❌      |     ❌     |     ✅        |     ✅     |
+|     Maximum   of the given dates   |     ✅      |     ✅     |     ✅        | ✅        |
+|     Minimum   of the given dates   |     ✅      |     ✅     |     ✅        |     ✅    |
 |                                    |            |           |              |           |
 |     **Manipulate**                     |            |           |              |           |
 |     Add                               |     ✅      |     ✅     |     ✅        |     ✅     |
@@ -1235,16 +1235,16 @@ DateTime.local().isValid;
 |                                    |            |           |              |           |
 |     **Display**                        |            |           |              |           |
 |     Format                         |     ❌      |     ✅     |     ✅        |     ✅     |
-|     Time   from now                |     ❌      |     ❌     |     ✅        | ⚠️        |
-|     Time   from X                  |     ❌      |     ❌     |     ✅        | ⚠️        |
+|     Time   from now                |     ❌      |     ❌     |     ✅        | ✅        |
+|     Time   from X                  |     ❌      |     ❌     |     ✅        | ✅        |
 |     Difference                     |     ✅      |     ✅     |     ✅        |     ✅     |
 |                                    |            |           |              |           |
 |     **Query**                          |            |           |              |           |
 |     Is   Before                    |     ✅      |     ✅     |     ✅        |     ✅     |
 |     Is Same                        | ✅          | ✅         | ✅            | ✅         |
 |     Is After                       | ✅          | ✅         | ✅            | ✅         |
-|     Is   Between                   |     ❌      | ✅         | ✅            | ⚠️        |
-|     Is   Leap Year                 |     ✅      |     ✅     |     ✅        | ⚠️        |
+|     Is   Between                   |     ❌      | ✅         | ✅            | ✅        |
+|     Is   Leap Year                 |     ✅      |     ✅     |     ✅        | ✅        |
 |     Is a   Date                    |     ✅      |     ✅     |     ✅        |     ✅     |
 
 # License


### PR DESCRIPTION
This RP removes all the ⚠️ in Feature Parity Table related to Day.js.

⚠️ Indicates other packages or work are needed. 
However,  in dayjs, all these plugins are all shipped  with main package, no other installation work or other packages needed.

That is to say, I think this is just a different API style instead of additional work.

See the API comparison between dayjs and date-fans, no difference, right?

```
// date-fns
import getISOWeeksInYear from 'date-fns/getISOWeeksInYear';
getISOWeeksInYear(new Date());
// => 52

// dayjs 
import isoWeeksInYear from 'dayjs/plugin/isoWeeksInYear'
dayjs.extend(isoWeeksInYear)
dayjs().isoWeeksInYear();
// => 52
```